### PR TITLE
Make detect_version_from_file return something

### DIFF
--- a/src/gfakluge.hpp
+++ b/src/gfakluge.hpp
@@ -748,6 +748,7 @@ namespace gfak{
                         header[h.key] = h;
                     } 
                 }
+                return this->version;
             };
 
             inline void for_each_sequence_line_in_file(const char* filename, std::function<void(const gfak::sequence_elem&)> func){


### PR DESCRIPTION
There's a missing return statement that has been breaking vg builds.